### PR TITLE
Add explicit UTF-8 encoding

### DIFF
--- a/src/obographs/model.py
+++ b/src/obographs/model.py
@@ -239,19 +239,31 @@ def get_id_to_edges(graph: Graph) -> dict[str, list[tuple[str, str]]]:
 # docstr-coverage:excused `overload`
 @overload
 def read(
-    source: str | Path, *, timeout: TimeoutHint = ..., squeeze: Literal[False] = ...
+    source: str | Path,
+    *,
+    timeout: TimeoutHint = ...,
+    squeeze: Literal[False] = ...,
+    encoding: str = ...,
 ) -> GraphDocument: ...
 
 
 # docstr-coverage:excused `overload`
 @overload
 def read(
-    source: str | Path, *, timeout: TimeoutHint = ..., squeeze: Literal[True] = ...
+    source: str | Path,
+    *,
+    timeout: TimeoutHint = ...,
+    squeeze: Literal[True] = ...,
+    encoding: str = ...,
 ) -> Graph: ...
 
 
 def read(
-    source: str | Path, *, timeout: TimeoutHint = None, squeeze: bool = True
+    source: str | Path,
+    *,
+    timeout: TimeoutHint = None,
+    squeeze: bool = True,
+    encoding: str = "utf-8",
 ) -> Graph | GraphDocument:
     """Read an OBO Graph document.
 
@@ -261,6 +273,7 @@ def read(
         only has a single graph and return a :class:`Graph` object. If `true` and
         multiple graphs are received, will raise an error. Set this to `false` to return
         a GraphDocument containing all graphs.
+    :param encoding: The encoding to use for reading the graph
 
     :returns: A graph or graph document
 
@@ -281,10 +294,10 @@ def read(
         if not path.is_file():
             raise FileNotFoundError
         if path.suffix.endswith(".gz"):
-            with gzip.open(path, mode="rt") as file:
+            with gzip.open(path, mode="rt", encoding=encoding) as file:
                 graph_document = GraphDocument.model_validate(json.load(file))
         else:
-            with path.open() as file:
+            with path.open(mode="rt", encoding=encoding) as file:
                 graph_document = GraphDocument.model_validate(json.load(file))
     else:
         raise TypeError(f"Unhandled source: {source}")


### PR DESCRIPTION
This helps avoid windows issues, because windows has cp1252 as its default encoding instead of utf8 for some reason

requested by @pfabry